### PR TITLE
deleting 'homepage' field from the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,4 @@
 {
-  "homepage": "http://glaubernespoli.github.io/dci-final-project-frontend",
   "name": "sell-your-records",
   "version": "0.1.0",
   "private": true,


### PR DESCRIPTION
It was added for the gh-pages branch and auto deploy plugin, but it's not working properly and messing up the startup on local dev.